### PR TITLE
3.6 Release

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#tool nuget:?package=NUnit.ConsoleRunner&version=3.4.1
+#tool nuget:?package=NUnit.ConsoleRunner&version=3.5.0
 
 //////////////////////////////////////////////////////////////////////
 // PROJECT-SPECIFIC
@@ -49,6 +49,8 @@ if (BuildSystem.IsRunningOnAppVeyor)
 
 			if (isPullRequest)
 				suffix += "-pr-" + AppVeyor.Environment.PullRequest.Number;
+			else if (AppVeyor.Environment.Repository.Branch.StartsWith("release", StringComparison.OrdinalIgnoreCase))
+				suffix += "-pre-" + buildNumber;
 			else
 				suffix += "-" + branch;
 

--- a/nunit.v2.driver.nuspec
+++ b/nunit.v2.driver.nuspec
@@ -15,7 +15,7 @@
     <releaseNotes></releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd runner</tags>
-    <copyright>Copyright (c) 2016 Charlie Poole</copyright>
+    <copyright>Copyright (c) 2017 Charlie Poole</copyright>
   </metadata>
   <files>
     <file src="../../LICENSE.txt" />

--- a/src/extension/Properties/AssemblyInfo.cs
+++ b/src/extension/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("nunit.v2.driver")]
-[assembly: AssemblyCopyright("Copyright © 2016")]
+[assembly: AssemblyCopyright("Copyright © 2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/extension/nunit.v2.driver.csproj
+++ b/src/extension/nunit.v2.driver.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.Api.3.5.0-dev-03131\lib\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.Api.3.5.0\lib\nunit.engine.api.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/extension/packages.config
+++ b/src/extension/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Engine.Api" version="3.5.0-dev-03131" targetFramework="net20" />
+  <package id="NUnit.Engine.Api" version="3.5.0" targetFramework="net20" />
 </packages>

--- a/src/nunit.v2.driver.tests/Properties/AssemblyInfo.cs
+++ b/src/nunit.v2.driver.tests/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("nunit.v2.driver.tests")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyCopyright("Copyright © 2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/nunit.v2.driver.tests/nunit.v2.driver.tests.csproj
+++ b/src/nunit.v2.driver.tests/nunit.v2.driver.tests.csproj
@@ -67,6 +67,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/nunit.v2.driver.tests/nunit.v2.driver.tests.csproj
+++ b/src/nunit.v2.driver.tests/nunit.v2.driver.tests.csproj
@@ -38,15 +38,15 @@
       <HintPath>..\extension\lib\nunit.core.interfaces.dll</HintPath>
     </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.Api.3.5.0-dev-03131\lib\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.Api.3.5.0\lib\nunit.engine.api.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.3.4.1\lib\net20\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.6.0\lib\net20\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NUnit.System.Linq, Version=0.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.3.4.1\lib\net20\NUnit.System.Linq.dll</HintPath>
+    <Reference Include="NUnit.System.Linq, Version=0.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.6.0\lib\net20\NUnit.System.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/nunit.v2.driver.tests/packages.config
+++ b/src/nunit.v2.driver.tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.4.1" targetFramework="net20" />
-  <package id="NUnit.Engine.Api" version="3.5.0-dev-03131" targetFramework="net20" />
+  <package id="NUnit" version="3.6.0" targetFramework="net20" />
+  <package id="NUnit.Engine.Api" version="3.5.0" targetFramework="net20" />
 </packages>

--- a/src/v2-test-assembly/Properties/AssemblyInfo.cs
+++ b/src/v2-test-assembly/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("v2-test-assembly")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
This was already marked as a 3.6 release and building as such in CI, so I left it as such even though it only has a handful of issues resolved. This updates the copyright to 2017 and fixes #3 by updating NUnit and the Engine.API to the latest released versions.

**Do not merge** but please review I will be tagging the release off this branch. I can increment the version to 3.7 or 3.6.1 as a separate PR. I think 3.6.1 is best based on the rate of change in the extensions.