### PR TITLE
Prepare for 3.7 release

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+NUnit V2 Framework Driver Extension 3.7 - August 10, 2017
+
+  Issues Resolved:
+    * 16 Integrate creation of chocolatey package into the build script
+    
 NUnit V2 Framework Driver Extension 3.6 - January 10, 2017
 
   Issues Resolved:

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2016 Charlie Poole
+Copyright (c) 2017 Charlie Poole
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build.cake
+++ b/build.cake
@@ -14,7 +14,7 @@ var GITHUB_SITE = "https://github.com/nunit/nunit-v2-framework-driver";
 var WIKI_PAGE = "https://github.com/nunit/docs/wiki/Console-Command-Line";
 var NUGET_ID = "NUnit.Extension.NUnitV2Driver";
 var CHOCO_ID = "nunit-extension-nunit-v2-driver";
-var VERSION = "3.6.1";
+var VERSION = "3.7.0";
 
 // Metadata used in the nuget and chocolatey packages
 var TITLE = "NUnit 3 - NUnit V2 Framework Driver Extension";

--- a/src/extension/Properties/AssemblyInfo.cs
+++ b/src/extension/Properties/AssemblyInfo.cs
@@ -23,5 +23,5 @@ using System.Runtime.InteropServices;
 [assembly: Guid("d9dde4fb-09c0-4a9a-924e-8691bf839092")]
 
 // Version of the extension
-[assembly: AssemblyVersion("3.6.1.0")]
-[assembly: AssemblyFileVersion("3.6.1.0")]
+[assembly: AssemblyVersion("3.7.0.0")]
+[assembly: AssemblyFileVersion("3.7.0.0")]


### PR DESCRIPTION
When merged, this will become the 3.7 release. Binaries are the same as 3.6 but a chocolatey package is included.