### PR TITLE
Include Repository URL in NuGet packaging, and update Cake Build

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -226,7 +226,7 @@ Task("RePackageNuGet")
                 Repository = new NuGetRepository {
                     Type = "git",
                     Url = GITHUB_SITE
-                }
+                },
                 Files = new [] {
                     new NuSpecContent { Source = PROJECT_DIR + "LICENSE.txt" },
                     new NuSpecContent { Source = PROJECT_DIR + "CHANGES.txt" },

--- a/build.cake
+++ b/build.cake
@@ -223,6 +223,10 @@ Task("RePackageNuGet")
                 Tags = TAGS,
                 //Language = "en-US",
                 OutputDirectory = OUTPUT_DIR,
+                Repository = new NuGetRepository {
+                    Type = "git",
+                    Url = GITHUB_SITE
+                }
                 Files = new [] {
                     new NuSpecContent { Source = PROJECT_DIR + "LICENSE.txt" },
                     new NuSpecContent { Source = PROJECT_DIR + "CHANGES.txt" },

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-	<package id="Cake" version="0.15.2" />
+	<package id="Cake" version="0.29.0" />
 </packages>


### PR DESCRIPTION
This is the basic change to have the Source Code link in the NuGet gallery.