### PR TITLE
Advance next version to 3.7.1 for development

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -14,7 +14,7 @@ var GITHUB_SITE = "https://github.com/nunit/nunit-v2-framework-driver";
 var WIKI_PAGE = "https://github.com/nunit/docs/wiki/Console-Command-Line";
 var NUGET_ID = "NUnit.Extension.NUnitV2Driver";
 var CHOCO_ID = "nunit-extension-nunit-v2-driver";
-var VERSION = "3.7.0";
+var VERSION = "3.7.1";
 
 // Metadata used in the nuget and chocolatey packages
 var TITLE = "NUnit 3 - NUnit V2 Framework Driver Extension";

--- a/src/extension/Properties/AssemblyInfo.cs
+++ b/src/extension/Properties/AssemblyInfo.cs
@@ -23,5 +23,5 @@ using System.Runtime.InteropServices;
 [assembly: Guid("d9dde4fb-09c0-4a9a-924e-8691bf839092")]
 
 // Version of the extension
-[assembly: AssemblyVersion("3.7.0.0")]
-[assembly: AssemblyFileVersion("3.7.0.0")]
+[assembly: AssemblyVersion("3.7.1.0")]
+[assembly: AssemblyFileVersion("3.7.1.0")]


### PR DESCRIPTION
Otherwise, new merges end up as 3.7.0-dev-xxxxx, which is prior to 3.7.0.